### PR TITLE
Apply initial patches

### DIFF
--- a/java/org/apache/catalina/webresources/AbstractArchiveResourceSet.java
+++ b/java/org/apache/catalina/webresources/AbstractArchiveResourceSet.java
@@ -251,7 +251,9 @@ public abstract class AbstractArchiveResourceSet extends AbstractResourceSet {
                     // Calls JarFile.getJarEntry() which is multi-release aware
                     jarEntry = getArchiveEntry(pathInJar);
                 } else {
-                    Map<String,JarEntry> jarEntries = getArchiveEntries(true);
+                    // Cache the jar entries after first read (single=false)...speeds up startup for
+                    // applications with a heavyweight classpath and significant up-front resource loading
+                    Map<String,JarEntry> jarEntries = getArchiveEntries(false);
                     if (!(pathInJar.charAt(pathInJar.length() - 1) == '/')) {
                         if (jarEntries == null) {
                             jarEntry = getArchiveEntry(pathInJar + '/');


### PR DESCRIPTION
Cache results of getArchiveEntries calls in ArchiveResourceSet.list
Improve application initialization performance by caching results
of getArchiveEntries to avoid continual rereading of jar contents

@see AN-107228: Improve ArchiveResourceSet lookup performance

--- 

Avoid unnecessary substring calls for ArchiveResourceSet lookup paths
Use less substrings When assembling archive lookup path to
reduce heap usage and GC during application startup

@see AN-107228: Improve ArchiveResourceSet lookup performance