### PR TITLE
DO NOT MERGE: Improve Tomcat classloading performance

### DIFF
--- a/build.properties.default
+++ b/build.properties.default
@@ -27,7 +27,7 @@ version.major=8
 version.minor=5
 version.build=45
 version.patch=0
-version.suffix=-dev
+version.suffix=
 
 # ----- Build control flags -----
 # Note enabling validation uses Checkstyle which is LGPL licensed

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+MSYS_NO_PATHCONV=1 docker run --rm -w="/usr/local/tomcat" -v $(pwd):/usr/local/tomcat webratio/ant:1.10.1 ant compile

--- a/java/org/apache/catalina/webresources/AbstractArchiveResourceSet.java
+++ b/java/org/apache/catalina/webresources/AbstractArchiveResourceSet.java
@@ -251,7 +251,9 @@ public abstract class AbstractArchiveResourceSet extends AbstractResourceSet {
                     // Calls JarFile.getJarEntry() which is multi-release aware
                     jarEntry = getArchiveEntry(pathInJar);
                 } else {
-                    Map<String,JarEntry> jarEntries = getArchiveEntries(true);
+                    // Cache the jar entries after first read (single=false)...speeds up startup for
+                    // applications with a heavyweight classpath and significant up-front resource loading
+                    Map<String,JarEntry> jarEntries = getArchiveEntries(false);
                     if (!(pathInJar.charAt(pathInJar.length() - 1) == '/')) {
                         if (jarEntries == null) {
                             jarEntry = getArchiveEntry(pathInJar + '/');

--- a/java/org/apache/catalina/webresources/AbstractArchiveResourceSet.java
+++ b/java/org/apache/catalina/webresources/AbstractArchiveResourceSet.java
@@ -39,7 +39,7 @@ public abstract class AbstractArchiveResourceSet extends AbstractResourceSet {
     private String baseUrlString;
 
     private JarFile archive = null;
-    protected HashMap<String,JarEntry> archiveEntries = null;
+    protected volatile HashMap<String,JarEntry> archiveEntries = null;
     protected final Object archiveLock = new Object();
     private long archiveUseCount = 0;
 

--- a/java/org/apache/catalina/webresources/AbstractSingleArchiveResourceSet.java
+++ b/java/org/apache/catalina/webresources/AbstractSingleArchiveResourceSet.java
@@ -63,29 +63,32 @@ public abstract class AbstractSingleArchiveResourceSet extends AbstractArchiveRe
 
     @Override
     protected HashMap<String,JarEntry> getArchiveEntries(boolean single) {
-        synchronized (archiveLock) {
-            if (archiveEntries == null && !single) {
-                JarFile jarFile = null;
-                archiveEntries = new HashMap<>();
-                try {
-                    jarFile = openJarFile();
-                    Enumeration<JarEntry> entries = jarFile.entries();
-                    while (entries.hasMoreElements()) {
-                        JarEntry entry = entries.nextElement();
-                        archiveEntries.put(entry.getName(), entry);
-                    }
-                } catch (IOException ioe) {
-                    // Should never happen
-                    archiveEntries = null;
-                    throw new IllegalStateException(ioe);
-                } finally {
-                    if (jarFile != null) {
-                        closeJarFile();
+        if (archiveEntries == null && !single) {
+            synchronized (archiveLock) {
+                if (archiveEntries == null) {
+                    JarFile jarFile = null;
+                    try {
+                        HashMap<String,JarEntry> contents = new HashMap<>();
+                        jarFile = openJarFile();
+                        Enumeration<JarEntry> entries = jarFile.entries();
+                        while (entries.hasMoreElements()) {
+                            JarEntry entry = entries.nextElement();
+                            contents.put(entry.getName(), entry);
+                        }
+                        archiveEntries = contents;
+                    } catch (IOException ioe) {
+                        // Should never happen
+                        archiveEntries = null;
+                        throw new IllegalStateException(ioe);
+                    } finally {
+                        if (jarFile != null) {
+                            closeJarFile();
+                        }
                     }
                 }
             }
-            return archiveEntries;
         }
+        return archiveEntries;
     }
 
 

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -44,7 +44,7 @@
   They eventually become mixed with the numbered issues (i.e., numbered
   issues do not "pop up" wrt. others).
 -->
-<section name="Tomcat 8.5.45 (markt)" rtext="in development">
+<section name="Tomcat 8.5.45 (markt)">
   <subsection name="Coyote">
     <changelog>
       <scode>


### PR DESCRIPTION
Jaxb and other XML libraries that do a lot of runtime scanning of the classpath have major performance issues due to a misplaced synchronization block in the AbstractSingleArchiveResourceSet

JIRA: https://issues.appian.com/browse/AN-125871