### PR TITLE
AN-125871: Improve Tomcat classloading performance

### DIFF
--- a/java/org/apache/catalina/webresources/AbstractArchiveResourceSet.java
+++ b/java/org/apache/catalina/webresources/AbstractArchiveResourceSet.java
@@ -339,6 +339,10 @@ public abstract class AbstractArchiveResourceSet extends AbstractResourceSet {
         }
     }
 
+    protected boolean isCacheArchiveEntries() {
+        return false;
+    }
+
     @Override
     public void gc() {
         synchronized (archiveLock) {
@@ -349,7 +353,9 @@ public abstract class AbstractArchiveResourceSet extends AbstractResourceSet {
                     // Log at least WARN
                 }
                 archive = null;
-                archiveEntries = null;
+                if (!isCacheArchiveEntries()) {
+                    archiveEntries = null;
+                }
             }
         }
     }


### PR DESCRIPTION
Jaxb and other XML libraries that do a lot of runtime scanning of the classpath have major performance issues due to a misplaced synchronization block in the AbstractSingleArchiveResourceSet

Tomcat gc() notes:

Called after startup: https://github.com/appian/tomcat/blob/trunk/java/org/apache/catalina/core/StandardContext.java#L5187-L5191

Background thread to do subsequent gc() at a regular interval started here: https://github.com/appian/tomcat/blob/trunk/java/org/apache/catalina/core/StandardContext.java#L5162-L5163

Note that the background thread does more than just cleanup the resource caches...it also cleans up sessions and other things: https://github.com/appian/tomcat/blob/trunk/java/org/apache/catalina/core/ContainerBase.java#L1261-L1284

gc() gets invoked from StandardRoot by the background thread: https://github.com/appian/tomcat/blob/trunk/java/org/apache/catalina/webresources/StandardRoot.java#L603-L618

@see AN-125871: Performance of com.appiancorp.common.xml.JaxbConverter